### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/mlee0996/661e18d6-fac7-4d2a-bc7c-52a20153b490/e1042332-b1bc-42f5-a439-a28de93bfd32/_apis/work/boardbadge/b24b20c5-c972-4e10-b1be-89276f355e3b)](https://dev.azure.com/mlee0996/661e18d6-fac7-4d2a-bc7c-52a20153b490/_boards/board/t/e1042332-b1bc-42f5-a439-a28de93bfd32/Microsoft.RequirementCategory)
 - 👋 Hi, I’m Mike Lee
 - 👀 I’m interested in all things Cloudy
 - 🌱 I’m currently learning about GHE and CI/CD


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mlee0996/661e18d6-fac7-4d2a-bc7c-52a20153b490/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.